### PR TITLE
Errors with the last change - ENTRYPOINT [ "python3" ]

### DIFF
--- a/kubernetes/tunhub/Dockerfile.breeze-agent-init
+++ b/kubernetes/tunhub/Dockerfile.breeze-agent-init
@@ -5,4 +5,4 @@ RUN apk add --no-cache --update python3 py3-pip  \
     && pip3 install boto3 requests
 
 COPY get-node-tags.py .
-CMD python3 get-node-tags.py
+ENTRYPOINT [ "python3" ]


### PR DESCRIPTION
get-node-tags.py  - file not found error with the last update, reverting this change allows the init pod to start normally.